### PR TITLE
[ghac] Fix error handing

### DIFF
--- a/ghac/.mbt.yml
+++ b/ghac/.mbt.yml
@@ -3,4 +3,4 @@ build:              # list of build commands to execute in each platform
   linux:
     cmd: ../scripts/build_binaries.sh
 properties:
-  version: "1.0.0"
+  version: "1.0.1"

--- a/ghac/github.go
+++ b/ghac/github.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -39,7 +38,7 @@ func (d *TeamFromYaml) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	sl := strings.Split(d.Slug, "-")
 	d.SlugPrefix = strings.Join(sl[:len(sl)-1], "-")
 	d.SlugSuffix = sl[len(sl)-1]
-	log.Debugf("SlugPrefix %v - SlugSuffix %v", d.SlugPrefix, d.SlugSuffix)
+
 	return nil
 }
 

--- a/ghac/main.go
+++ b/ghac/main.go
@@ -51,7 +51,9 @@ func main() {
 
 	app.Flags = flags
 
-	app.Run(os.Args)
+	if err := app.Run(os.Args); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func run(c *cli.Context) error {
@@ -62,9 +64,9 @@ func run(c *cli.Context) error {
 	}
 	log.SetLevel(logLevel)
 
-	// log.Debugf("source: %v", c.String("source"))
-	// log.Debugf("destination: %v", c.String("destination"))
-	// log.Debugf("template: %v", c.String("template"))
+	log.Debugf("source: %v", c.String("source"))
+	log.Debugf("destination: %v", c.String("destination"))
+	log.Debugf("template: %v", c.String("template"))
 
 	//TODO: Add more validations
 	dstDirName := path.Dir(c.String("destination"))
@@ -95,10 +97,13 @@ func run(c *cli.Context) error {
 	for _, t := range tl.Teams {
 		if regexFilter == nil || regexFilter.MatchString(t.Slug) {
 			// render template to destination (1 file per team)
-			f, err := os.Create(path.Join(dstDirName, fmt.Sprintf("%v%v", t.Slug, suffix)))
+			p := path.Join(dstDirName, fmt.Sprintf("%v%v", t.Slug, suffix))
+			f, err := os.Create(p)
 			if err != nil {
 				return err
 			}
+
+			log.Debugf("rendering template for %s to %s", t.Slug, p)
 			err = RenderTemplate((*Team)(t), tpl, f)
 			f.Close()
 			if err != nil {


### PR DESCRIPTION
## Problem

`run` function does return errors during workflow, but `main` does not check the return of `app.Run` so errors inside the handler are ignored and program fails silently on errors.

## Solution

Have `main` check the return value of `app.Run` (which is the same as the handlers) & terminate via `log.Fatalf` if there's an error.